### PR TITLE
Fix issue with loading minified js in npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stickUp",
   "version": "2.3.1",
-  "main": "src/stickUp.js",
+  "main": "build/js/stickUp.min.js",
   "description": "A simple jQuery plugin for sticking elements in different scenarios",
   "author": "Patrik Powalowski",
   "license": "MIT",


### PR DESCRIPTION
When using stickUp JS as a library in a project, the js had console out's.  The main in the package json was pointing to the dev version of the library instead of production minified js. 